### PR TITLE
Add fastmcp server dockerization with API key auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# yet_another_mcp
-# mcp_dockerized
+# MCP Dockerized Server
+
+This repository provides a minimal MCP server based on [fastmcp].
+The server exposes the Streamable HTTP transport and protects all
+requests using a simple API key.
+
+## Usage
+
+### Build and run with Docker
+
+```bash
+docker build -t mcp-server .
+docker run -p 8000:8000 -v mcp_data:/data mcp-server
+```
+
+The container stores API keys in `/data/api_keys.db`. Mount a volume to
+persist keys across restarts.
+
+### Generate API keys
+
+Use the management CLI inside the container to create keys:
+
+```bash
+docker run --rm -v mcp_data:/data mcp-server python manage.py generate-key
+```
+
+The printed key can then be supplied via the `X-API-Key` header or
+`api_key` query parameter when calling the server.

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,20 @@
+import typer
+from server import init_db, create_api_key
+
+app = typer.Typer(help="MCP server management")
+
+@app.command()
+def init_db_command():
+    """Initialize the database."""
+    init_db()
+    typer.echo("Database initialized")
+
+@app.command()
+def generate_key():
+    """Generate a new API key."""
+    init_db()
+    key = create_api_key()
+    typer.echo(key)
+
+if __name__ == "__main__":
+    app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp
+uvicorn

--- a/server.py
+++ b/server.py
@@ -1,0 +1,58 @@
+import secrets
+import sqlite3
+from pathlib import Path
+
+from fastmcp.server import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+DB_PATH = Path("/data/api_keys.db")
+
+
+def init_db() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS api_keys (key TEXT PRIMARY KEY)"
+        )
+
+
+def create_api_key() -> str:
+    key = secrets.token_hex(32)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("INSERT INTO api_keys (key) VALUES (?)", (key,))
+    return key
+
+
+def validate_key(key: str) -> bool:
+    with sqlite3.connect(DB_PATH) as conn:
+        row = conn.execute("SELECT 1 FROM api_keys WHERE key=?", (key,)).fetchone()
+    return row is not None
+
+
+class APIKeyMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") == "http":
+            request = Request(scope, receive)
+            key = request.headers.get("x-api-key") or request.query_params.get(
+                "api_key"
+            )
+            if not key or not validate_key(key):
+                response = JSONResponse({"detail": "Invalid API key"}, status_code=401)
+                await response(scope, receive, send)
+                return
+        await self.app(scope, receive, send)
+
+
+init_db()
+fast_mcp = FastMCP()
+app = fast_mcp.streamable_http_app()
+app.add_middleware(APIKeyMiddleware)
+
+
+@app.route("/generate-key", methods=["POST"])
+async def generate_key(_: Request) -> JSONResponse:
+    return JSONResponse({"api_key": create_api_key()})


### PR DESCRIPTION
## Summary
- implement a minimal FastMCP server
- add API key middleware and key generation route
- provide a management CLI for generating keys
- add Dockerfile and requirements
- document how to build and run the container

## Testing
- `python -m py_compile server.py manage.py`

------
https://chatgpt.com/codex/tasks/task_e_68536329282c8323a0443c11380ddde6