### PR TITLE
Fix deprecation warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastmcp
 uvicorn
+typer

--- a/server.py
+++ b/server.py
@@ -49,10 +49,12 @@ class APIKeyMiddleware:
 
 init_db()
 fast_mcp = FastMCP()
-app = fast_mcp.streamable_http_app()
+app = fast_mcp.http_app()
 app.add_middleware(APIKeyMiddleware)
 
 
-@app.route("/generate-key", methods=["POST"])
 async def generate_key(_: Request) -> JSONResponse:
     return JSONResponse({"api_key": create_api_key()})
+
+
+app.add_route("/generate-key", generate_key, methods=["POST"])


### PR DESCRIPTION
## Summary
- use FastMCP.http_app() instead of deprecated streamable_http_app()
- register /generate-key route with `add_route`
- include `typer` in requirements

## Testing
- `python manage.py generate-key`

------
https://chatgpt.com/codex/tasks/task_e_6853732c7cb48323be7153930bc413c1