### PR TITLE
Fix APIKeyMiddleware to allow docs

### DIFF
--- a/server.py
+++ b/server.py
@@ -38,13 +38,15 @@ class APIKeyMiddleware:
     async def __call__(self, scope, receive, send):
         if scope.get("type") == "http":
             request = Request(scope, receive)
-            key = request.headers.get("x-api-key") or request.query_params.get(
-                "api_key"
-            )
-            if not key or not validate_key(key):
-                response = JSONResponse({"detail": "Invalid API key"}, status_code=401)
-                await response(scope, receive, send)
-                return
+            # allow unauthenticated access to documentation endpoints
+            if request.url.path not in {"/docs", "/openapi.json"}:
+                key = request.headers.get("x-api-key") or request.query_params.get(
+                    "api_key"
+                )
+                if not key or not validate_key(key):
+                    response = JSONResponse({"detail": "Invalid API key"}, status_code=401)
+                    await response(scope, receive, send)
+                    return
         await self.app(scope, receive, send)
 
 


### PR DESCRIPTION
## Summary
- allow openapi docs to be accessed without authentication

## Testing
- `python -m py_compile server.py manage.py`
- manual `curl` to `/docs` and `/openapi.json`

------
https://chatgpt.com/codex/tasks/task_e_68537a1eb81c8323b4bd118298ec3fb1