### PR TITLE
Fix port mismatch and add logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+import logging
 import secrets
 import sqlite3
 from pathlib import Path
@@ -12,6 +13,9 @@ from urllib.parse import parse_qs
 
 DB_PATH = Path("/data/api_keys.db")
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 def init_db() -> None:
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -19,18 +23,22 @@ def init_db() -> None:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS api_keys (key TEXT PRIMARY KEY)"
         )
+    logger.info("Database initialized at %s", DB_PATH)
 
 
 def create_api_key() -> str:
     key = secrets.token_hex(32)
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("INSERT INTO api_keys (key) VALUES (?)", (key,))
+    logger.info("Created a new API key")
     return key
 
 
 def validate_key(key: str) -> bool:
     with sqlite3.connect(DB_PATH) as conn:
         row = conn.execute("SELECT 1 FROM api_keys WHERE key=?", (key,)).fetchone()
+    if row is None:
+        logger.warning("Invalid API key attempted: %s", key[:8])
     return row is not None
 
 
@@ -40,8 +48,8 @@ class APIKeyMiddleware:
 
     async def __call__(self, scope, receive, send):
         if scope.get("type") == "http":
-
             path = scope.get("path", "")
+            logger.info("Handling request for %s", path)
             if path not in {"/docs", "/openapi.json"}:
                 headers = {k.decode().lower(): v.decode() for k, v in scope.get("headers", [])}
                 key = headers.get("x-api-key")
@@ -49,8 +57,14 @@ class APIKeyMiddleware:
                     query = parse_qs(scope.get("query_string", b"").decode())
                     values = query.get("api_key")
                     key = values[0] if values else None
+                    if not key:
+                        logger.warning("Missing API key for request to %s", path)
+                        response = JSONResponse({"detail": "Invalid API key"}, status_code=401)
+                        await response(scope, receive, send)
+                        return
 
-                if not key or not validate_key(key):
+                if not validate_key(key):
+                    logger.warning("Invalid API key for request to %s", path)
                     response = JSONResponse({"detail": "Invalid API key"}, status_code=401)
                     await response(scope, receive, send)
                     return
@@ -60,12 +74,15 @@ class APIKeyMiddleware:
 init_db()
 fast_mcp = FastMCP()
 app = fast_mcp.http_app()
+logger.info("FastMCP application initialized")
 app.add_middleware(APIKeyMiddleware)
 app.mount("/static", StaticFiles(directory=swagger_ui_path), name="static")
 
 
 async def generate_key(_: Request) -> JSONResponse:
-    return JSONResponse({"api_key": create_api_key()})
+    key = create_api_key()
+    logger.info("API key generated via endpoint")
+    return JSONResponse({"api_key": key})
 
 
 app.add_route("/generate-key", generate_key, methods=["POST"])
@@ -109,3 +126,4 @@ async def swagger(_: Request) -> HTMLResponse:
 
 app.add_route("/openapi.json", openapi, methods=["GET"])
 app.add_route("/docs", swagger, methods=["GET"])
+logger.info("Routes registered. Server ready.")


### PR DESCRIPTION
## Summary
- make the container run on port 8000 to match docs
- add basic logging to server for easier troubleshooting

## Testing
- `python -m py_compile server.py manage.py`
- `docker build -t mcp-server .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68548188c58483238ad417a3cc3dc07b