### PR TITLE
Allow /doc without API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The server exposes two simple HTTP endpoints:
 | `/mcp` | `POST` | Streamable HTTP transport for MCP requests. Requires a valid API key. |
 | `/generate-key` | `POST` | Generates a new API key. Requires an existing valid API key. |
 
-Interactive API documentation is available at [`/docs`](http://localhost:8000/docs) with the raw schema at [`/openapi.json`](http://localhost:8000/openapi.json).
+Interactive API documentation is available at [`/docs`](http://localhost:8000/docs) (also accessible via `/doc`) with the raw schema at [`/openapi.json`](http://localhost:8000/openapi.json).
 
 ## Example requests
 

--- a/server.py
+++ b/server.py
@@ -50,7 +50,7 @@ class APIKeyMiddleware:
         if scope.get("type") == "http":
             path = scope.get("path", "")
             logger.info("Handling request for %s", path)
-            if path not in {"/docs", "/openapi.json"}:
+            if path not in {"/docs", "/doc", "/openapi.json"}:
                 headers = {k.decode().lower(): v.decode() for k, v in scope.get("headers", [])}
                 key = headers.get("x-api-key")
                 if not key:
@@ -126,4 +126,5 @@ async def swagger(_: Request) -> HTMLResponse:
 
 app.add_route("/openapi.json", openapi, methods=["GET"])
 app.add_route("/docs", swagger, methods=["GET"])
+app.add_route("/doc", swagger, methods=["GET"])
 logger.info("Routes registered. Server ready.")


### PR DESCRIPTION
## Summary
- serve the swagger UI under `/doc` as well as `/docs`
- exclude `/doc` from API key middleware checks
- document the new alias in the README

## Testing
- `python -m py_compile server.py manage.py`

------
https://chatgpt.com/codex/tasks/task_e_685484288f9c832387bdc21de42b74a3