### PR TITLE
Add plugin loader and terminal tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ async def main():
 
 asyncio.run(main())
 ```
+
+## Plugins
+
+Additional tools and resources can be added by placing modules in the
+`plugins` package. Each module should expose a `setup(server)` function
+which receives the `FastMCP` instance and registers tools or resources.
+All modules in this package are automatically imported on startup.
+
+This repository ships with a `terminal` plugin providing a simple tool
+for running commands on the host system.

--- a/plugins/terminal.py
+++ b/plugins/terminal.py
@@ -1,0 +1,15 @@
+import asyncio
+from fastmcp.server import FastMCP
+
+
+def setup(server: FastMCP) -> None:
+    @server.tool(name="terminal", description="Run a shell command on the host")
+    async def terminal(cmd: str) -> str:
+        """Execute a command on the host system and return its output."""
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await proc.communicate()
+        return stdout.decode()

--- a/server.py
+++ b/server.py
@@ -4,6 +4,8 @@ import sqlite3
 from pathlib import Path
 
 from fastmcp.server import FastMCP
+import importlib
+import pkgutil
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.staticfiles import StaticFiles
 from swagger_ui_bundle import swagger_ui_path
@@ -42,6 +44,24 @@ def validate_key(key: str) -> bool:
     return row is not None
 
 
+PLUGINS_PACKAGE = "plugins"
+
+
+def load_plugins(server: FastMCP, package: str = PLUGINS_PACKAGE) -> None:
+    """Load tool and resource plugins from the given package."""
+    try:
+        pkg = importlib.import_module(package)
+    except ModuleNotFoundError:
+        logger.warning("Plugins package %s not found", package)
+        return
+
+    for _, module_name, _ in pkgutil.iter_modules(pkg.__path__):
+        module = importlib.import_module(f"{package}.{module_name}")
+        setup = getattr(module, "setup", None)
+        if callable(setup):
+            setup(server)
+
+
 class APIKeyMiddleware:
     def __init__(self, app):
         self.app = app
@@ -73,6 +93,7 @@ class APIKeyMiddleware:
 
 init_db()
 fast_mcp = FastMCP()
+load_plugins(fast_mcp)
 app = fast_mcp.http_app()
 logger.info("FastMCP application initialized")
 app.add_middleware(APIKeyMiddleware)


### PR DESCRIPTION
## Summary
- implement plugin loading in `server.py`
- document plugin usage in README
- add `plugins` package with a terminal tool plugin

## Testing
- `python -m py_compile server.py plugins/terminal.py plugins/__init__.py`
- `python - <<'PY'
import asyncio, server
async def main():
    tools = await server.fast_mcp.get_tools()
    print('tools', list(tools.keys()))
asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68548ccbd9a88323bd4fd68eb829bffa