### PR TITLE
Fix FastMCP client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ For more advanced interaction you can use the `fastmcp` Python client:
 
 ```python
 import asyncio
-import fastmcp
+from fastmcp.client import Client, StreamableHttpTransport
 
 async def main():
-    transport = fastmcp.StreamableHttpTransport(
+    transport = StreamableHttpTransport(
         "http://localhost:8000/mcp",
         headers={"X-API-Key": "<your-api-key>"},
     )
-    async with fastmcp.Client(transport) as client:
+    async with Client(transport) as client:
         tools = await client.list_tools()
         print(tools)
 


### PR DESCRIPTION
## Summary
- fix client import path in README example

## Testing
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_6854977f03c483239da086aead2b123f